### PR TITLE
Manage additional params in the plugin

### DIFF
--- a/atlasprint/README.md
+++ b/atlasprint/README.md
@@ -29,6 +29,8 @@ This plugin adds some new requests with the `ATLAS` service:
     * Comma separated list of values. If set, these predefined scales are used. Exclusive with `SCALE`.
     * For instance `SCALES=400,1000`.
 
+The plugin also accept arbitrary key value pairs to manipulate item label text in composition. The key is the id (lower case) of the label text component and the value, the content that will override it default content.
+
 The only config that the plugin will not follow is the file pattern defined in QGIS Desktop, if it outputs many PDF.
 
 This plugin also adds some new requests to the `WMS` service for backward compatibility:

--- a/atlasprint/core.py
+++ b/atlasprint/core.py
@@ -149,10 +149,9 @@ def print_atlas(project, layout_name, feature_filter, scales=None, scale=None, *
     
     for key, value in kwargs.items():
         QgsMessageLog.logMessage('Additional parameters: {} = {}'.format(key, value), 'atlasprint', Qgis.Info)
-        if layout.itemById(key.lower()):
-            if isinstance(layout.itemById(key.lower()), QgsLayoutItemLabel):
-                item = layout.itemById(key.lower())
-                item.setText(value)
+        item = layout.itemById(key.lower())
+        if isinstance(item, QgsLayoutItemLabel):
+            item.setText(value)
 
     layer = atlas.coverageLayer()
     feature_filter = optimize_expression(layer, feature_filter)

--- a/atlasprint/core.py
+++ b/atlasprint/core.py
@@ -83,7 +83,7 @@ def project_scales(project):
     return scales
 
 
-def print_atlas(project, layout_name, feature_filter, scales=None, scale=None):
+def print_atlas(project, layout_name, feature_filter, scales=None, scale=None, **kwargs):
     """Generate an atlas.
 
     :param project: The project to render as atlas.
@@ -145,6 +145,12 @@ def print_atlas(project, layout_name, feature_filter, scales=None, scale=None):
             settings.predefinedMapScales = scales
         else:
             layout.reportContext().setPredefinedScales(scales)
+    
+    for key, value in kwargs.items():
+        QgsMessageLog.logMessage('Additional parameters: %s = %s' % (key, value), 'atlasprint', Qgis.Info)
+        if layout.itemById(key.lower()):
+            item = layout.itemById(key.lower())
+            item.setText(value)
 
     layer = atlas.coverageLayer()
     feature_filter = optimize_expression(layer, feature_filter)

--- a/atlasprint/core.py
+++ b/atlasprint/core.py
@@ -12,6 +12,7 @@ from qgis.core import (
     QgsMessageLog,
     QgsMasterLayoutInterface,
     QgsSettings,
+    QgsLayoutItemLabel,
     QgsLayoutItemMap,
     QgsLayoutExporter,
     QgsExpression,
@@ -147,10 +148,11 @@ def print_atlas(project, layout_name, feature_filter, scales=None, scale=None, *
             layout.reportContext().setPredefinedScales(scales)
     
     for key, value in kwargs.items():
-        QgsMessageLog.logMessage('Additional parameters: %s = %s' % (key, value), 'atlasprint', Qgis.Info)
+        QgsMessageLog.logMessage('Additional parameters: {} = {}'.format(key, value), 'atlasprint', Qgis.Info)
         if layout.itemById(key.lower()):
-            item = layout.itemById(key.lower())
-            item.setText(value)
+            if isinstance(layout.itemById(key.lower()), QgsLayoutItemLabel):
+                item = layout.itemById(key.lower())
+                item.setText(value)
 
     layer = atlas.coverageLayer()
     feature_filter = optimize_expression(layer, feature_filter)

--- a/atlasprint/service.py
+++ b/atlasprint/service.py
@@ -179,12 +179,15 @@ class AtlasPrintService(QgsService):
                 except ValueError:
                     raise AtlasPrintException('Invalid number in SCALES.')
 
+            additional_params = {k: v for k, v in params.items() if k not in ['TEMPLATE', 'EXP_FILTER', 'SCALE', 'SCALES']}
+
             pdf_path = print_atlas(
                 project=project,
                 layout_name=params['TEMPLATE'],
                 scale=scale,
                 scales=scales,
-                feature_filter=feature_filter
+                feature_filter=feature_filter,
+                **additional_params
             )
         except AtlasPrintException as e:
             raise AtlasPrintError(400, 'ATLAS - Error from the user while generating the PDF: {}'.format(e))


### PR DESCRIPTION
Instead of "losing" the additional parameters, we change code so we can set parameters from the URL in the ATLAS to change the text items content in a composition if the item id match the additional parameter. We may change this behavior also to set custom image URL in another PR instead of only setting text like in this PR.