### PR TITLE
Fix warning about deprecated methods about scales

### DIFF
--- a/atlasprint/core.py
+++ b/atlasprint/core.py
@@ -183,8 +183,8 @@ def print_layout(
                 settings.predefinedMapScales = scales
 
             if not scales and atlas_layout.referenceMap().atlasScalingMode() == QgsLayoutItemMap.Predefined:
-                use_project = project.useProjectScales()
-                map_scales = project.mapScales()
+                use_project = project.viewSettings().useProjectScales()
+                map_scales = project.viewSettings().mapScales()
                 if not use_project or len(map_scales) == 0:
                     logger.info(
                         f'Request-ID {request_id}, map scales not found in project, fetching predefined map scales in '


### PR DESCRIPTION
Try to fix these messages

```
/srv/qgis/plugins/atlasprint/core.py:186: DeprecationWarning:

QgsProject.useProjectScales() is deprecated

/srv/qgis/plugins/atlasprint/core.py:187: DeprecationWarning:

QgsProject.mapScales() is deprecated

```

QGIS 3.10 introduces the `QgsProjectViewSettings` Class that contains settings and properties relating to how a QgsProject should be displayed inside map canvas, e.g.

Fixes #37
Funded by Cartophyl

<!-- Add "fix" in front of # if it fixes the ticket or do nothing to only mention it -->
* Ticket : #
* 
