### PR TITLE
Set default DPI to 100

### DIFF
--- a/atlasprint/core.py
+++ b/atlasprint/core.py
@@ -122,6 +122,9 @@ def print_layout(
         # PDF by default
         settings = QgsLayoutExporter.PdfExportSettings()
 
+    # Set DPI to 100
+    settings.dpi = 100
+
     atlas = None
     atlas_layout = None
     report_layout = None


### PR DESCRIPTION
To speed up atlas rendering, and to avoid to many tiles rendering, the DPI is set to 100.